### PR TITLE
Address Event update and data fix

### DIFF
--- a/Observer/Customer/Address.php
+++ b/Observer/Customer/Address.php
@@ -32,16 +32,10 @@ class Address implements ObserverInterface
     {
 
         $address = $observer->getCustomerAddress();
-        $customerId = $address->getCustomerId();
-        $customer = $this->customerModel->getById($address->getCustomerId());
-    
-        if(!$customer){
-            return $this;
-        }
 
         try{                                                                  
             $request = new Webhook($this->logger);
-            $response = $request->post('profile.updated', $customer->__toArray());
+            $response = $request->post('address.updated', $address->toArray());
         }catch(\Exception $e){
             $this->logger->debug($e);
         }


### PR DESCRIPTION
Changed Address observer name to allow differentiating between observer events. 
Simplified event context to just the customer address taken directly from the observer. 